### PR TITLE
Bugfix: Use upstream instead of target branch

### DIFF
--- a/upstream-sync.sh
+++ b/upstream-sync.sh
@@ -37,7 +37,7 @@ fi
 echo "::set-output name=has_new_commits::true"
 # display commits since last sync
 echo 'New commits being pulled:' 1>&1
-git log upstream/"${INPUT_TARGET_BRANCH}" "${LOCAL_COMMIT_HASH}"..HEAD --pretty=oneline
+git log upstream/"${INPUT_UPSTREAM_BRANCH}" "${LOCAL_COMMIT_HASH}"..HEAD --pretty=oneline
 
 # pull from upstream to target_branch
 echo 'Pulling...' 1>&1


### PR DESCRIPTION
I'm pulling from upstream/master to a branch with a different name (`ansible-st2-tracking`).
That branch is not in the upstream repo, so this gave the error:
```
New commits being pulled:
fatal: ambiguous argument 'upstream/ansible-st2-tracking': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
```