### PR TITLE
Configurable git sync command (and other git args)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,17 @@ As with any Github Action, you must include it in a workflow for your repo to ru
 
 ### Input Variables
 
-| Name                | Required?           | Default  | Example |
-| ------------------- |:------------------: | -------- | ----------
-| upstream_repository | :white_check_mark:  |          | aormsby/Fork-Sync-With-Upstream-action        |
-| upstream_branch     | :white_check_mark:  | 'master' | 'master'                                      |
-| target_branch       | :white_check_mark:  | 'master' | 'master'                                      |
-| github_token        |                     |          | ${{ secrets.GITHUB_TOKEN }}                   |
-| git_sync_command    |                     | 'pull'   | 'pull' or 'merge --ff-only' or 'reset --hard' |
+| Name                | Required?           | Default           | Example |
+| ------------------- |:------------------: | ----------------- | ----------
+| upstream_repository | :white_check_mark:  |                   | aormsby/Fork-Sync-With-Upstream-action        |
+| upstream_branch     | :white_check_mark:  | 'master'          | 'master'                                      |
+| target_branch       | :white_check_mark:  | 'master'          | 'master'                                      |
+| github_token        |                     |                   | ${{ secrets.GITHUB_TOKEN }}                   |
+| git_checkout_args   |                     | ''                | '--recurse-submodules'                        |
+| git_fetch_args      |                     | ''                | '--recurse-submodules'                        |
+| git_log_format_args |                     | '--prety=oneline' | '--graph --pretty=oneline'                    |
+| git_sync_command    |                     | 'pull'            | 'pull' or 'merge --ff-only' or 'reset --hard' |
+| git_push_args       |                     | ''                | '--force'                                     |
 
 For **github_token** - use `${{ secrets.GITHUB_TOKEN }}` where `GITHUB_TOKEN` is the name of the secret in your repo ([see docs for help](https://docs.github.com/en/actions/configuring-and-managing-workflows/using-variables-and-secrets-in-a-workflow))
 

--- a/README.md
+++ b/README.md
@@ -12,10 +12,11 @@ As with any Github Action, you must include it in a workflow for your repo to ru
 
 | Name                | Required?           | Default  | Example |
 | ------------------- |:------------------: | -------- | ----------
-| upstream_repository | :white_check_mark:  |          | aormsby/Fork-Sync-With-Upstream-action |
-| upstream_branch     | :white_check_mark:  | 'master' | 'master'                               |
-| target_branch       | :white_check_mark:  | 'master' | 'master'                               |
-| github_token        |                     |          | ${{ secrets.GITHUB_TOKEN }}            |
+| upstream_repository | :white_check_mark:  |          | aormsby/Fork-Sync-With-Upstream-action        |
+| upstream_branch     | :white_check_mark:  | 'master' | 'master'                                      |
+| target_branch       | :white_check_mark:  | 'master' | 'master'                                      |
+| github_token        |                     |          | ${{ secrets.GITHUB_TOKEN }}                   |
+| git_sync_command    |                     | 'pull'   | 'pull' or 'merge --ff-only' or 'reset --hard' |
 
 For **github_token** - use `${{ secrets.GITHUB_TOKEN }}` where `GITHUB_TOKEN` is the name of the secret in your repo ([see docs for help](https://docs.github.com/en/actions/configuring-and-managing-workflows/using-variables-and-secrets-in-a-workflow))
 
@@ -31,7 +32,7 @@ Right now, the `main.js` script only exists to execute `upstream-sync.sh`. It's 
 2. Make sure the right local branch is checked out (`target_branch`)
 3. Add the upstream repo you listed
 4. Check if there are any new commits to sync (and prints any new commits as oneline statements)
-5. Pull from the upstream repo
+5. Sync from the upstream repo (generally by pulling)
 6. Push to the target branch of the target repo
 
 **Ta-da!**
@@ -58,14 +59,15 @@ jobs:
         ref: master
 
     # Step 2: run this sync action - specify the upstream repo, upstream branch to sync with, and target sync branch
-    - name: Pull upstream changes
+    - name: Pull (Fast-Forward) upstream changes
       id: sync
       uses: aormsby/Fork-Sync-With-Upstream-action@v1
       with:
         upstream_repository: panr/hugo-theme-hello-friend
         upstream_branch: master
-        target_branch: master                       # optional
-        github_token: ${{ secrets.GITHUB_TOKEN }}   # optional, for accessing repos that requir authentication
+        target_branch: master
+        git_sync_command: pull --ff-only            # optional, defaults to pull
+        github_token: ${{ secrets.GITHUB_TOKEN }}   # optional, for accessing repos that require authentication
 
     # Step 3: Display a message if 'sync' step had new commits (simple test)
     - name: Check for new commits

--- a/action.yaml
+++ b/action.yaml
@@ -25,10 +25,30 @@ inputs:
     required: true
     default: 'master'
 
+  git_checkout_args:
+    description: 'Any extra args to pass to `git checkout` like --recurse-submodules (only used when current branch is not target_branch), default = ""'
+    required: false
+    default: ''
+
+  git_fetch_args:
+    description: 'Any extra args to pass to `git fetch` like --recurse-submodules, default = ""'
+    required: false
+    default: ''
+
+  git_log_format_args:
+    description: 'How to print the list of new commits, default = --pretty=oneline'
+    required: false
+    default: '--pretty=oneline'
+
   git_sync_command:
     description: 'Which git command to use for sync (eg "merge --ff-only" or "reset --hard"), default = pull'
     required: false
     default: 'pull'
+
+  git_push_args:
+    description: 'Any extra args to pass to `git push` like --force, default = ""'
+    required: false
+    default: ''
 
 outputs:
   has_new_commits:

--- a/action.yaml
+++ b/action.yaml
@@ -25,6 +25,11 @@ inputs:
     required: true
     default: 'master'
 
+  git_sync_command:
+    description: 'Which git command to use for sync (eg "merge --ff-only" or "reset --hard"), default = pull'
+    required: false
+    default: 'pull'
+
 outputs:
   has_new_commits:
     description: 'true when new commits were included in this sync.'

--- a/action.yaml
+++ b/action.yaml
@@ -16,7 +16,7 @@ inputs:
     required: true
 
   upstream_branch:
-    description: 'Branch to pull from, default = master'
+    description: 'Branch to sync from, default = master'
     required: true
     default: 'master'
 

--- a/upstream-sync.sh
+++ b/upstream-sync.sh
@@ -41,7 +41,9 @@ git log upstream/"${INPUT_UPSTREAM_BRANCH}" "${LOCAL_COMMIT_HASH}"..HEAD --prett
 
 # pull from upstream to target_branch
 echo 'Pulling...' 1>&1
-git pull upstream "${INPUT_UPSTREAM_BRANCH}"
+# do not quote SYNC_COMMAND. It may contain more than one argument.
+# examples: "pull", "merge --ff-only", "reset --hard"
+git ${INPUT_GIT_SYNC_COMMAND} upstream "${INPUT_UPSTREAM_BRANCH}"
 echo 'Pull successful' 1>&1
 
 # push to origin target_branch

--- a/upstream-sync.sh
+++ b/upstream-sync.sh
@@ -36,15 +36,15 @@ fi
 
 echo "::set-output name=has_new_commits::true"
 # display commits since last sync
-echo 'New commits being pulled:' 1>&1
+echo 'New commits being synced:' 1>&1
 git log upstream/"${INPUT_UPSTREAM_BRANCH}" "${LOCAL_COMMIT_HASH}"..HEAD --pretty=oneline
 
-# pull from upstream to target_branch
-echo 'Pulling...' 1>&1
+# sync from upstream to target_branch
+echo 'Syncing...' 1>&1
 # do not quote SYNC_COMMAND. It may contain more than one argument.
-# examples: "pull", "merge --ff-only", "reset --hard"
+# sync_command examples: "pull", "merge --ff-only", "reset --hard"
 git ${INPUT_GIT_SYNC_COMMAND} upstream "${INPUT_UPSTREAM_BRANCH}"
-echo 'Pull successful' 1>&1
+echo 'Sync successful' 1>&1
 
 # push to origin target_branch
 echo 'Pushing to target branch...' 1>&1


### PR DESCRIPTION
I want to make sure that no merge commits are ever added to my upstream tracking branch. So, I need to use one of these:

- `git pull --ff-only <commitish>`
- `git merge --ff-only <commitish>`
- `git reset --hard <commitish>`

To make this possible, add a new `git_sync_command` input option. This defaults to `pull` to retain the current behavior of using `git pull <commitish>`.

This also makes args for `git checkout`, `git fetch`, `git log`, and `git push` configurable.

~This is built on top of #5, so #5 should be merged first.~ _merged_