### PR TITLE
Default to 'main' instead of 'master'

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,11 @@ As with any Github Action, you must include it in a workflow for your repo to ru
 
 | Name                | Required?           | Default  | Example |
 | ------------------- |:------------------: | -------- | ----------
-| upstream_repository | :white_check_mark:  |          | aormsby/Fork-Sync-With-Upstream-action |
-| upstream_branch     | :white_check_mark:  | 'master' | 'master'                               |
-| target_branch       | :white_check_mark:  | 'master' | 'master'                               |
-| github_token        |                     |          | ${{ secrets.GITHUB_TOKEN }}            |
+| upstream_repository | :white_check_mark:  |          | aormsby/Fork-Sync-With-Upstream-action        |
+| upstream_branch     | :white_check_mark:  | 'master' | 'master'                                      |
+| target_branch       | :white_check_mark:  | 'master' | 'master'                                      |
+| github_token        |                     |          | ${{ secrets.GITHUB_TOKEN }}                   |
+| git_sync_command    |                     | 'pull'   | 'pull' or 'merge --ff-only' or 'reset --hard' |
 
 For **github_token** - use `${{ secrets.GITHUB_TOKEN }}` where `GITHUB_TOKEN` is the name of the secret in your repo ([see docs for help](https://docs.github.com/en/actions/configuring-and-managing-workflows/using-variables-and-secrets-in-a-workflow))
 
@@ -31,7 +32,7 @@ Right now, the `main.js` script only exists to execute `upstream-sync.sh`. It's 
 2. Make sure the right local branch is checked out (`target_branch`)
 3. Add the upstream repo you listed
 4. Check if there are any new commits to sync (and prints any new commits as oneline statements)
-5. Pull from the upstream repo
+5. Sync from the upstream repo (generally by pulling)
 6. Push to the target branch of the target repo
 
 **Ta-da!**
@@ -58,14 +59,15 @@ jobs:
         ref: master
 
     # Step 2: run this sync action - specify the upstream repo, upstream branch to sync with, and target sync branch
-    - name: Pull upstream changes
+    - name: Pull (Fast-Forward) upstream changes
       id: sync
       uses: aormsby/Fork-Sync-With-Upstream-action@v1
       with:
         upstream_repository: panr/hugo-theme-hello-friend
         upstream_branch: master
-        target_branch: master                       # optional
-        github_token: ${{ secrets.GITHUB_TOKEN }}   # optional, for accessing repos that requir authentication
+        target_branch: master
+        git_sync_command: pull --ff-only            # optional, defaults to pull
+        github_token: ${{ secrets.GITHUB_TOKEN }}   # optional, for accessing repos that require authentication
 
     # Step 3: Display a message if 'sync' step had new commits (simple test)
     - name: Check for new commits

--- a/README.md
+++ b/README.md
@@ -10,13 +10,17 @@ As with any Github Action, you must include it in a workflow for your repo to ru
 
 ### Input Variables
 
-| Name                | Required?           | Default  | Example |
-| ------------------- |:------------------: | -------- | ----------
-| upstream_repository | :white_check_mark:  |          | aormsby/Fork-Sync-With-Upstream-action        |
-| upstream_branch     | :white_check_mark:  | 'master' | 'master'                                      |
-| target_branch       | :white_check_mark:  | 'master' | 'master'                                      |
-| github_token        |                     |          | ${{ secrets.GITHUB_TOKEN }}                   |
-| git_sync_command    |                     | 'pull'   | 'pull' or 'merge --ff-only' or 'reset --hard' |
+| Name                    | Required?           | Default           | Example |
+| ----------------------- |:------------------: | ----------------- | ----------
+| upstream_repository     | :white_check_mark:  |                   | aormsby/Fork-Sync-With-Upstream-action        |
+| upstream_branch         | :white_check_mark:  | 'master'          | 'master'                                      |
+| target_branch           | :white_check_mark:  | 'master'          | 'master'                                      |
+| github_token            |                     |                   | ${{ secrets.GITHUB_TOKEN }}                   |
+| git_checkout_extra_args |                     | ''                | '--recurse-submodules'                        |
+| git_fetch_extra_args    |                     | ''                | '--recurse-submodules'                        |
+| git_log_format_args     |                     | '--prety=oneline' | '--graph --pretty=oneline'                    |
+| git_sync_command        |                     | 'pull'            | 'pull' or 'merge --ff-only' or 'reset --hard' |
+| git_push_extra_args     |                     | ''                | '--force'                                     |
 
 For **github_token** - use `${{ secrets.GITHUB_TOKEN }}` where `GITHUB_TOKEN` is the name of the secret in your repo ([see docs for help](https://docs.github.com/en/actions/configuring-and-managing-workflows/using-variables-and-secrets-in-a-workflow))
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ As with any Github Action, you must include it in a workflow for your repo to ru
 | Name                    | Required?           | Default           | Example |
 | ----------------------- |:------------------: | ----------------- | ----------
 | upstream_repository     | :white_check_mark:  |                   | aormsby/Fork-Sync-With-Upstream-action        |
-| upstream_branch         | :white_check_mark:  | 'master'          | 'master'                                      |
-| target_branch           | :white_check_mark:  | 'master'          | 'master'                                      |
+| upstream_branch         |                     | 'main'            | 'master'                                      |
+| target_branch           |                     | 'main'            | 'main'                                        |
 | github_token            |                     |                   | ${{ secrets.GITHUB_TOKEN }}                   |
 | git_checkout_extra_args |                     | ''                | '--recurse-submodules'                        |
 | git_fetch_extra_args    |                     | ''                | '--recurse-submodules'                        |
@@ -53,14 +53,14 @@ on:
 jobs:
   sync_with_upstream:
     runs-on: ubuntu-latest
-    name: Sync master with upstream latest
+    name: Sync main with upstream latest
 
     steps:
     # Step 1: run a standard checkout action, provided by github
-    - name: Checkout master
+    - name: Checkout main
       uses: actions/checkout@v2
       with:
-        ref: master
+        ref: main
 
     # Step 2: run this sync action - specify the upstream repo, upstream branch to sync with, and target sync branch
     - name: Pull (Fast-Forward) upstream changes
@@ -68,8 +68,8 @@ jobs:
       uses: aormsby/Fork-Sync-With-Upstream-action@v1
       with:
         upstream_repository: panr/hugo-theme-hello-friend
-        upstream_branch: master
-        target_branch: master
+        upstream_branch: master                     # optional, defaults to main
+        target_branch: main                         # optional, defaults to main
         git_sync_command: pull --ff-only            # optional, defaults to pull
         github_token: ${{ secrets.GITHUB_TOKEN }}   # optional, for accessing repos that require authentication
 

--- a/action.yaml
+++ b/action.yaml
@@ -1,6 +1,6 @@
 name: 'Fork Sync With Upstream'
 author: 'Adam Ormsby (@aormsby)'
-description: 'Automatically updates fork with new commits from upstream repo, run on an unmodified branch (usually master)'
+description: 'Automatically updates fork with new commits from upstream repo, run on an unmodified branch (usually main)'
 
 branding:
   icon: refresh-ccw
@@ -16,14 +16,14 @@ inputs:
     required: true
 
   upstream_branch:
-    description: 'Branch to sync from, default = master'
-    required: true
-    default: 'master'
+    description: 'Branch to sync from, default = main'
+    required: false
+    default: 'main'
 
   target_branch:
-    description: 'Branch to push to, default = master'
-    required: true
-    default: 'master'
+    description: 'Branch to push to, default = main'
+    required: false
+    default: 'main'
 
   git_checkout_extra_args:
     description: 'Any extra args to pass to `git checkout` like --recurse-submodules (only used when current branch is not target_branch), default = ""'

--- a/action.yaml
+++ b/action.yaml
@@ -25,10 +25,30 @@ inputs:
     required: true
     default: 'master'
 
+  git_checkout_extra_args:
+    description: 'Any extra args to pass to `git checkout` like --recurse-submodules (only used when current branch is not target_branch), default = ""'
+    required: false
+    default: ''
+
+  git_fetch_extra_args:
+    description: 'Any extra args to pass to `git fetch` like --recurse-submodules, default = ""'
+    required: false
+    default: ''
+
+  git_log_format_args:
+    description: 'How to print the list of new commits, default = --pretty=oneline'
+    required: false
+    default: '--pretty=oneline'
+
   git_sync_command:
     description: 'Which git command to use for sync (eg "merge --ff-only" or "reset --hard"), default = pull'
     required: false
     default: 'pull'
+
+  git_push_extra_args:
+    description: 'Any extra args to pass to `git push` like --force, default = ""'
+    required: false
+    default: ''
 
 outputs:
   has_new_commits:

--- a/action.yaml
+++ b/action.yaml
@@ -25,6 +25,11 @@ inputs:
     required: true
     default: 'master'
 
+  git_sync_command:
+    description: 'Which git command to use for sync (eg "merge --ff-only" or "reset --hard"), default = pull'
+    required: false
+    default: 'pull'
+
 outputs:
   has_new_commits:
     description: 'true when new commits were included in this sync.'

--- a/action.yaml
+++ b/action.yaml
@@ -16,7 +16,7 @@ inputs:
     required: true
 
   upstream_branch:
-    description: 'Branch to pull from, default = master'
+    description: 'Branch to sync from, default = master'
     required: true
     default: 'master'
 

--- a/upstream-sync.sh
+++ b/upstream-sync.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 
 set -e
+# do not quote GIT_SYNC_COMMAND or GIT_*_ARGS. As they may contain
+# more than one argument.
 
 # fail if upstream_repository is not set in workflow
 if [ -z "${INPUT_UPSTREAM_REPOSITORY}" ]; then
@@ -13,7 +15,7 @@ fi
 
 # ensure target_branch is checked out
 if [ $(git branch --show-current) != "${INPUT_TARGET_BRANCH}" ]; then
-    git checkout "${INPUT_TARGET_BRANCH}"
+    git checkout ${INPUT_GIT_CHECKOUT_EXTRA_ARGS} "${INPUT_TARGET_BRANCH}"
     echo 'Target branch ' ${INPUT_TARGET_BRANCH} ' checked out' 1>&1
 fi
 
@@ -24,7 +26,7 @@ git remote add upstream "${UPSTREAM_REPO}"
 # git remote -v
 
 # check latest commit hashes for a match, exit if nothing to sync
-git fetch upstream "${INPUT_UPSTREAM_BRANCH}"
+git fetch ${INPUT_GIT_FETCH_EXTRA_ARGS} upstream "${INPUT_UPSTREAM_BRANCH}"
 LOCAL_COMMIT_HASH=$(git rev-parse "${INPUT_TARGET_BRANCH}")
 UPSTREAM_COMMIT_HASH=$(git rev-parse upstream/"${INPUT_UPSTREAM_BRANCH}")
 
@@ -37,16 +39,15 @@ fi
 echo "::set-output name=has_new_commits::true"
 # display commits since last sync
 echo 'New commits being synced:' 1>&1
-git log upstream/"${INPUT_UPSTREAM_BRANCH}" "${LOCAL_COMMIT_HASH}"..HEAD --pretty=oneline
+git log upstream/"${INPUT_UPSTREAM_BRANCH}" "${LOCAL_COMMIT_HASH}"..HEAD ${INPUT_GIT_LOG_FORMAT_ARGS}
 
 # sync from upstream to target_branch
 echo 'Syncing...' 1>&1
-# do not quote SYNC_COMMAND. It may contain more than one argument.
 # sync_command examples: "pull", "merge --ff-only", "reset --hard"
 git ${INPUT_GIT_SYNC_COMMAND} "${INPUT_UPSTREAM_BRANCH}"
 echo 'Sync successful' 1>&1
 
 # push to origin target_branch
 echo 'Pushing to target branch...' 1>&1
-git push origin "${INPUT_TARGET_BRANCH}"
+git push ${INPUT_GIT_PUSH_EXTRA_ARGS} origin "${INPUT_TARGET_BRANCH}"
 echo 'Push successful' 1>&1

--- a/upstream-sync.sh
+++ b/upstream-sync.sh
@@ -41,7 +41,9 @@ git log upstream/"${INPUT_UPSTREAM_BRANCH}" "${LOCAL_COMMIT_HASH}"..HEAD --prett
 
 # pull from upstream to target_branch
 echo 'Pulling...' 1>&1
-git pull upstream "${INPUT_UPSTREAM_BRANCH}"
+# do not quote SYNC_COMMAND. It may contain more than one argument.
+# examples: "pull", "merge --ff-only", "reset --hard"
+git ${INPUT_GIT_SYNC_COMMAND} "${INPUT_UPSTREAM_BRANCH}"
 echo 'Pull successful' 1>&1
 
 # push to origin target_branch

--- a/upstream-sync.sh
+++ b/upstream-sync.sh
@@ -36,15 +36,15 @@ fi
 
 echo "::set-output name=has_new_commits::true"
 # display commits since last sync
-echo 'New commits being pulled:' 1>&1
+echo 'New commits being synced:' 1>&1
 git log upstream/"${INPUT_UPSTREAM_BRANCH}" "${LOCAL_COMMIT_HASH}"..HEAD --pretty=oneline
 
-# pull from upstream to target_branch
-echo 'Pulling...' 1>&1
+# sync from upstream to target_branch
+echo 'Syncing...' 1>&1
 # do not quote SYNC_COMMAND. It may contain more than one argument.
-# examples: "pull", "merge --ff-only", "reset --hard"
+# sync_command examples: "pull", "merge --ff-only", "reset --hard"
 git ${INPUT_GIT_SYNC_COMMAND} "${INPUT_UPSTREAM_BRANCH}"
-echo 'Pull successful' 1>&1
+echo 'Sync successful' 1>&1
 
 # push to origin target_branch
 echo 'Pushing to target branch...' 1>&1


### PR DESCRIPTION
Resolves #7

Since the branch args are currently required, changing the default from master to main is backwards compatible.
Anyone who is using the action is currently defining which branches to use.

Built on top of #6, so merge #6 first.