### PR TITLE
Fix sync command

### DIFF
--- a/upstream-sync.sh
+++ b/upstream-sync.sh
@@ -44,7 +44,13 @@ git log upstream/"${INPUT_UPSTREAM_BRANCH}" "${LOCAL_COMMIT_HASH}"..HEAD ${INPUT
 # sync from upstream to target_branch
 echo 'Syncing...' 1>&1
 # sync_command examples: "pull", "merge --ff-only", "reset --hard"
-git ${INPUT_GIT_SYNC_COMMAND} upstream "${INPUT_UPSTREAM_BRANCH}"
+if [[ "$INPUT_GIT_SYNC_COMMAND" =~ ^pull.* ]]; then
+    # pull takes remote and branch as two args.
+    git ${INPUT_GIT_SYNC_COMMAND} upstream "${INPUT_UPSTREAM_BRANCH}"
+else
+    # merge and reset take remote and branch as one args.
+    git ${INPUT_GIT_SYNC_COMMAND} upstream/"${INPUT_UPSTREAM_BRANCH}"
+fi
 echo 'Sync successful' 1>&1
 
 # push to origin target_branch


### PR DESCRIPTION
It turns out I missed that `git pull` has slightly different args than `git merge` or `git reset`.
So this treats it differently.

I couldn't think of a more concise way to clean that up. Any ideas?