### PR TITLE
has_new_commits: don't try to set false result

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -63,6 +63,11 @@ inputs:
     required: false
     default: 'false'
 
+  git_reset:
+    description: 'Set to run "git fetch" + "git reset" instead of git pull. Used for branchs that can be rewound/force pushed.'
+    required: false
+    default: ''
+
 outputs:
   has_new_commits:
     description: 'true when new commits were included in this sync'

--- a/upstream-sync.sh
+++ b/upstream-sync.sh
@@ -97,7 +97,11 @@ git log upstream/"${INPUT_UPSTREAM_BRANCH}" "${LOCAL_COMMIT_HASH}"..HEAD ${INPUT
 # sync from upstream to target_branch
 echo 'Syncing...' 1>&1
 # pull_args examples: "--ff-only", "--tags"
-git pull --no-edit ${INPUT_GIT_PULL_ARGS} upstream "${INPUT_UPSTREAM_BRANCH}"
+if [ -n ${INPUT_GIT_RESET} ]; then
+    git reset --hard upstream/"${INPUT_UPSTREAM_BRANCH}"
+else
+    git pull --no-edit ${INPUT_GIT_PULL_ARGS} upstream "${INPUT_UPSTREAM_BRANCH}"
+fi
 echo 'Sync successful' 1>&1
 
 # push to origin target_branch

--- a/upstream-sync.sh
+++ b/upstream-sync.sh
@@ -84,7 +84,6 @@ LOCAL_COMMIT_HASH=$(git rev-parse "${INPUT_TARGET_BRANCH}")
 UPSTREAM_COMMIT_HASH=$(git rev-parse upstream/"${INPUT_UPSTREAM_BRANCH}")
 
 if [ "${LOCAL_COMMIT_HASH}" = "${UPSTREAM_COMMIT_HASH}" ]; then
-    echo "::set-output name=has_new_commits::false"
     echo 'No new commits to sync, exiting' 1>&1
     reset_git
     exit 0


### PR DESCRIPTION
As per investigation in #21, Actions evaluates the string false as
boolean true. The easiest workaround is to simply not bother setting
a false result. Actions will then interpret no result as false, which
is exactly what we want.