### PR TITLE
Don't try to set false result

### DIFF
--- a/upstream-sync.sh
+++ b/upstream-sync.sh
@@ -84,7 +84,6 @@ LOCAL_COMMIT_HASH=$(git rev-parse "${INPUT_TARGET_BRANCH}")
 UPSTREAM_COMMIT_HASH=$(git rev-parse upstream/"${INPUT_UPSTREAM_BRANCH}")
 
 if [ "${LOCAL_COMMIT_HASH}" = "${UPSTREAM_COMMIT_HASH}" ]; then
-    echo "::set-output name=has_new_commits::false"
     echo 'No new commits to sync, exiting' 1>&1
     reset_git
     exit 0


### PR DESCRIPTION
As per investigation in #21, Actions evaluates the string false as
boolean true. The easiest workaround is to simply not bother setting
a false result. Actions will then interpret no result as false, which
is exactly what we want.

(Originally this was PR #25 , but I had to close that one due to branch complications.)