### PR TITLE
Fix: Git config conflicts with other actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ An action with forks in mind! Automatically sync a branch on your fork with the 
 
 **Bonus:** This action can also sync between branches on any two repositories. So you have options. :slightly_smiling_face:
 
+**\*\*FIXED in v3.1:\*\*** Git config values are now set only if they haven't been set elsewhere by other actions in a workflow. This was done to avoid conflict setting config values in other job steps (like [gpg commit signing](https://github.com/aormsby/Fork-Sync-With-Upstream-action/wiki/GPG-Signing))
+
 **\*\*NEW in v3:\*\*** Test Mode runs key checks on your input values to help you verify your action configuration before running and avoid errors when you go live! ([wiki](https://github.com/aormsby/Fork-Sync-With-Upstream-action/wiki#test-mode))
 
 <a href="https://www.buymeacoffee.com/aormsby" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/default-green.png" alt="Buy Me A Coffee" style="height: 51px !important;width: 217px !important;" ></a>
@@ -101,7 +103,7 @@ jobs:
     # Step 2: run the sync action
     - name: Sync upstream changes
       id: sync
-      uses: aormsby/Fork-Sync-With-Upstream-action@v3.0
+      uses: aormsby/Fork-Sync-With-Upstream-action@v3.1
       with:
         target_sync_branch: my-branch
         # REQUIRED 'target_repo_token' exactly like this!

--- a/run/config_git.sh
+++ b/run/config_git.sh
@@ -2,7 +2,7 @@
 
 # called by run_action.sh
 config_for_action() {
-    write_out -1 "Setting git config from input vars. (Skips each config if input is set to 'null'.)"
+    write_out -1 "Setting git config from input vars. (Skips config for all inputs set to 'null'.)"
     get_current_user_config
     set_git_config "${INPUT_GIT_CONFIG_USER}" "${INPUT_GIT_CONFIG_EMAIL}" "${INPUT_GIT_CONFIG_PULL_REBASE}"
     write_out "g" "SUCCESS\n"
@@ -12,21 +12,24 @@ config_for_action() {
 get_current_user_config() {
     CURRENT_USER=$(git config --get --default="null" user.name)
     CURRENT_EMAIL=$(git config --get --default="null" user.email)
-    CURRENT_PULL_CONFIG=$(git config --get --default="null" pull.rebase)
+    CURRENT_PULL_CONFIG=$(git config --get --default="false" pull.rebase)
 }
 
 # set action config values
 set_git_config() {
-    # only set config if user did not set input var to "null"
-    if [ "${INPUT_GIT_CONFIG_USER}" != "null" ]; then
+    # only set user if config is empty
+    if [ "${CURRENT_USER}" = "null" ] &&
+        [ "${1}" != "null" ]; then
         git config user.name "${1}"
     fi
 
-    # only set config if user did not set input var to "null"
-    if [ "${INPUT_GIT_CONFIG_EMAIL}" != "null" ]; then
+    # only set email if config is empty
+    if [ "${CURRENT_EMAIL}" = "null" ] &&
+        [ "${2}" != "null" ]; then
         git config user.email "${2}"
     fi
 
+    # always set pull.rebase with worflow value (default false)
     git config pull.rebase "${3}"
 }
 
@@ -46,11 +49,7 @@ reset_git_config() {
         git config user.email "${CURRENT_EMAIL}"
     fi
 
-    if [ "${CURRENT_PULL_CONFIG}" = "null" ]; then
-        git config --unset pull.rebase
-    else
-        git config pull.rebase "${CURRENT_PULL_CONFIG}"
-    fi
+    git config pull.rebase "${CURRENT_PULL_CONFIG}"
 
     write_out "b" "Reset Complete\n"
 }

--- a/test/verify_git_config.sh
+++ b/test/verify_git_config.sh
@@ -13,7 +13,7 @@ test_config_git() {
 get_current_user_config() {
     CURRENT_USER=$(git config --get --default="null" user.name)
     CURRENT_EMAIL=$(git config --get --default="null" user.email)
-    CURRENT_PULL_CONFIG=$(git config --get --default="null" pull.rebase)
+    CURRENT_PULL_CONFIG=$(git config --get --default="false" pull.rebase)
 }
 
 # set action config values

--- a/test/verify_git_config.sh
+++ b/test/verify_git_config.sh
@@ -58,6 +58,7 @@ verify_set_config() {
 
 # reset to original user config values
 reset_git_config() {
+    # unset user if value was previously null, else reset
     if [ "${CURRENT_USER}" = "null" ]; then
         git config --unset user.name
         CURRENT_USER=""
@@ -65,6 +66,7 @@ reset_git_config() {
         git config user.name "${CURRENT_USER}"
     fi
 
+    # unset email if value was previously null, else reset
     if [ "${CURRENT_EMAIL}" = "null" ]; then
         git config --unset user.email
         CURRENT_EMAIL=""
@@ -72,12 +74,8 @@ reset_git_config() {
         git config user.email "${CURRENT_EMAIL}"
     fi
 
-    if [ "${CURRENT_PULL_CONFIG}" = "null" ]; then
-        git config --unset pull.rebase
-        CURRENT_PULL_CONFIG=""
-    else
-        git config pull.rebase "${CURRENT_PULL_CONFIG}"
-    fi
+    # always reset pull.rebase
+    git config pull.rebase "${CURRENT_PULL_CONFIG}"
 }
 
 # verify original values


### PR DESCRIPTION
This probably should have been the functionality anyway, but the reason for this change is to avoid conflicts with git configurations set by other actions running in the same workflow.

For example, using another action like [Import GPG](https://github.com/marketplace/actions/import-gpg) to enable gpg signing would have failed before since the sync action overrode any git config values that Import GPG would have set. Now the sync sets config values a little more carefully - i.e. only when they're empty.

An example of using Import GPG on the sync wiki - https://github.com/aormsby/Fork-Sync-With-Upstream-action/wiki/GPG-Signing

This PR 's changes are currently testable by setting `uses: aormsby/Fork-Sync-With-Upstream-action@feature/gpg` in your workflow's sync step.

Fixes issue #33 