### PR TITLE
Improve new commit check and fix 'first sync' shallow issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ Want more output variables? [Open an issue](https://github.com/aormsby/Fork-Sync
 ## Sample Workflow
 
 ```yaml
+name: 'Usptream Sync'
+
 on:
   schedule:
     - cron:  '0 7 * * 1,4'

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ An action with forks in mind! Automatically sync a branch on your fork with the 
 
 **Bonus:** This action can also sync between branches on any two repositories. So you have options. :slightly_smiling_face:
 
-**\*\*FIXED in v3.1:\*\*** Git config values are now set only if they haven't been set elsewhere by other actions in a workflow. This was done to avoid conflict setting config values in other job steps (like [gpg commit signing](https://github.com/aormsby/Fork-Sync-With-Upstream-action/wiki/GPG-Signing))
+**\*\*FIXED in v3.2:\*\*** Checking for new commits to sync has been improved to better support active development branches. Instead of only comparing head SHA values, it does a deeper hash comparison between the target and upstream branches since the last action run. Length of time is based on new input var `shallow_since`, which defaults to `1 month ago`. ([wiki](https://github.com/aormsby/Fork-Sync-With-Upstream-action/wiki/Configuration#advanced-use))
 
 **\*\*NEW in v3:\*\*** Test Mode runs key checks on your input values to help you verify your action configuration before running and avoid errors when you go live! ([wiki](https://github.com/aormsby/Fork-Sync-With-Upstream-action/wiki#test-mode))
 
@@ -47,16 +47,19 @@ This action supports syncing from both public and private upstream repos. Store 
 
 #### Advanced Use (all optional args)
 
-| Name                        |     Required?      | Default                     | Example                    |
-| --------------------------- | :----------------: | --------------------------- | -------------------------- |
-| host_domain                 | :white_check_mark: | 'github.com'                | 'github.com'               |
-| target_branch_checkout_args |                    |                             | '--recurse-submodules'     |
-| git_log_format_args         |                    | '--pretty=oneline'          | '--graph --pretty=oneline' |
-| upstream_pull_args          |                    |                             | '--ff-only --tags'         |
-| target_branch_push_args     |                    |                             | '--force'                  |
-| git_config_user             |                    | 'GH Action - Upstream Sync' |                            |
-| git_config_email            |                    | 'action@github.com'         |                            |
-| git_config_pull_rebase      |                    | 'false'                     |                            |
+| Name                        |     Required?      | Default                     | Example                             |
+| --------------------------- | :----------------: | --------------------------- | ----------------------------------- |
+| host_domain                 | :white_check_mark: | 'github.com'                | 'github.com'                        |
+| shallow_since               | :white_check_mark: | '1 month ago'               | '2 days ago', '3 weeks 7 hours ago' |
+| target_branch_checkout_args |                    |                             | '--recurse-submodules'              |
+| git_log_format_args         |                    | '--pretty=oneline'          | '--graph --pretty=oneline'          |
+| upstream_pull_args          |                    |                             | '--ff-only --tags'                  |
+| target_branch_push_args     |                    |                             | '--force'                           |
+| git_config_user             |                    | 'GH Action - Upstream Sync' |                                     |
+| git_config_email            |                    | 'action@github.com'         |                                     |
+| git_config_pull_rebase      |                    | 'false'                     |                                     |
+
+`shallow_since` -> Value should match the time between workflow runs to get the history depth required (but no more) for a good check of new commits to sync
 
 ##### Git Config Settings
 
@@ -103,7 +106,7 @@ jobs:
     # Step 2: run the sync action
     - name: Sync upstream changes
       id: sync
-      uses: aormsby/Fork-Sync-With-Upstream-action@v3.1
+      uses: aormsby/Fork-Sync-With-Upstream-action@v3.2
       with:
         target_sync_branch: my-branch
         # REQUIRED 'target_repo_token' exactly like this!

--- a/action.yaml
+++ b/action.yaml
@@ -72,6 +72,11 @@ inputs:
     required: true
     default: 'github.com'
 
+  shallow_since:
+    description: 'Length of time used when fetching shallow repo data, should match how often you perform a sync'
+    required: true
+    default: '1 month ago'
+
 outputs:
   has_new_commits:
     description: 'true when new commits were included in this sync'

--- a/entry/run_action.sh
+++ b/entry/run_action.sh
@@ -1,23 +1,20 @@
 #!/bin/sh
 
+# shellcheck disable=SC1091
 # source action scripts, then run individual functions
 
-# shellcheck disable=SC1091
 # config git settings
 . "${ACTION_PARENT_DIR}"/run/config_git.sh
 config_for_action
 
-# shellcheck disable=SC1091
 # checkout target branch in target repo
 . "${ACTION_PARENT_DIR}"/run/checkout_branch.sh
 checkout
 
-# shellcheck disable=SC1091
 # set upstream repo
 . "${ACTION_PARENT_DIR}"/run/set_upstream_repo.sh
 set_upstream
 
-# shellcheck disable=SC1091
 # check for new commits and sync or exit
 . "${ACTION_PARENT_DIR}"/run/get_updates.sh
 check_for_updates
@@ -25,7 +22,6 @@ find_last_synced_commit
 output_new_commit_list
 sync_new_commits
 
-# shellcheck disable=SC1091
 # push newly synced commits to local branch
 . "${ACTION_PARENT_DIR}"/run/push_updates.sh
 push_new_commits

--- a/entry/run_action.sh
+++ b/entry/run_action.sh
@@ -25,11 +25,11 @@ find_last_synced_commit
 output_new_commit_list
 sync_new_commits
 
-# # shellcheck disable=SC1091
-# # push newly synced commits to local branch
-# . "${ACTION_PARENT_DIR}"/run/push_updates.sh
-# push_new_commits
+# shellcheck disable=SC1091
+# push newly synced commits to local branch
+. "${ACTION_PARENT_DIR}"/run/push_updates.sh
+push_new_commits
 
-# # git config cleanup for workflow continuation
-# # function from config_git.sh
-# reset_git_config
+# git config cleanup for workflow continuation
+# function from config_git.sh
+reset_git_config

--- a/entry/run_action.sh
+++ b/entry/run_action.sh
@@ -21,8 +21,9 @@ set_upstream
 # check for new commits and sync or exit
 . "${ACTION_PARENT_DIR}"/run/get_updates.sh
 check_for_updates
-# output_new_commit_list
-# sync_new_commits
+find_last_synced_commit
+output_new_commit_list
+sync_new_commits
 
 # # shellcheck disable=SC1091
 # # push newly synced commits to local branch

--- a/entry/run_action.sh
+++ b/entry/run_action.sh
@@ -21,14 +21,14 @@ set_upstream
 # check for new commits and sync or exit
 . "${ACTION_PARENT_DIR}"/run/get_updates.sh
 check_for_updates
-output_new_commit_list
-sync_new_commits
+# output_new_commit_list
+# sync_new_commits
 
-# shellcheck disable=SC1091
-# push newly synced commits to local branch
-. "${ACTION_PARENT_DIR}"/run/push_updates.sh
-push_new_commits
+# # shellcheck disable=SC1091
+# # push newly synced commits to local branch
+# . "${ACTION_PARENT_DIR}"/run/push_updates.sh
+# push_new_commits
 
-# git config cleanup for workflow continuation
-# function from config_git.sh
-reset_git_config
+# # git config cleanup for workflow continuation
+# # function from config_git.sh
+# reset_git_config

--- a/run/get_updates.sh
+++ b/run/get_updates.sh
@@ -63,8 +63,12 @@ find_last_synced_commit() {
 
 # display new commits since last sync
 output_new_commit_list() {
-    write_out -1 '\nNew commits since last sync:'
-    git log upstream/"${INPUT_UPSTREAM_SYNC_BRANCH}" "${LAST_SYNCED_COMMIT}"..HEAD ${INPUT_GIT_LOG_FORMAT_ARGS}
+    if [ -z "${LAST_SYNCED_COMMIT}" ]; then
+        write_out -1 "\nNo previous sync found from upstream repo. Syncing entire commit history."
+    else
+        write_out -1 '\nNew commits since last sync:'
+        git log upstream/"${INPUT_UPSTREAM_SYNC_BRANCH}" "${LAST_SYNCED_COMMIT}"..HEAD ${INPUT_GIT_LOG_FORMAT_ARGS}
+    fi
 }
 
 # sync from upstream to target_sync_branch

--- a/run/get_updates.sh
+++ b/run/get_updates.sh
@@ -6,9 +6,8 @@
 check_for_updates() {
     write_out -1 'Checking for new commits on upstream branch.\n'
 
-    # TODO: extract shallow since var
     # fetch commits from upstream branch within given time frame (default 1 month)
-    git fetch --quiet --shallow-since="1 month ago" upstream "${INPUT_UPSTREAM_SYNC_BRANCH}"
+    git fetch --quiet --shallow-since="${INPUT_SHALLOW_SINCE}" upstream "${INPUT_UPSTREAM_SYNC_BRANCH}"
     COMMAND_STATUS=$?
 
     if [ "${COMMAND_STATUS}" != 0 ]; then
@@ -19,9 +18,8 @@ check_for_updates() {
 
     UPSTREAM_COMMIT_HASH=$(git rev-parse "upstream/${INPUT_UPSTREAM_SYNC_BRANCH}")
 
-    # TODO: extract shallow since var
     # check is latest upstream hash is in target branch
-    git fetch --quiet --shallow-since="1 month ago" origin "${INPUT_TARGET_SYNC_BRANCH}"
+    git fetch --quiet --shallow-since="${INPUT_SHALLOW_SINCE}" origin "${INPUT_TARGET_SYNC_BRANCH}"
     BRANCH_WITH_LATEST="$(git branch "${INPUT_TARGET_SYNC_BRANCH}" --contains="${UPSTREAM_COMMIT_HASH}")"
 
     if [ -z "${UPSTREAM_COMMIT_HASH}" ]; then


### PR DESCRIPTION
Fix based on issue #36 

Previously, the action checked for new commits rather naively by comparing the heads of the target and upstream branches and looking for a difference. However, that didn't account for the situation where the target branch has new commits unrelated to syncing.

Now, the action loops through all of the commit hashes since the last sync (actually, going back to the `shallow_since` time), and does a more thorough check to see if a new sync is needed or not.

- `shallow_since` was added with default `1 month ago`
- An unshallow operation was added to deal with 'first sync' situations
- Commit log output was improved