### PR TITLE
Update `push_updates.sh` to fix `git remote set-url` command

### DIFF
--- a/run/push_updates.sh
+++ b/run/push_updates.sh
@@ -5,8 +5,8 @@ push_new_commits() {
     write_out -1 'Pushing synced data to target branch.'
 
     # TODO: figure out how this would work in local mode...
-    # update origin url with token since it is not persisted during checkout step when syncing from a private repo
-    if [ -n "${INPUT_UPSTREAM_REPO_ACCESS_TOKEN}" ]; then
+    # update remote url with token since it is not persisted during checkout step when syncing from a private repo
+    if [ -n "${INPUT_TARGET_REPO_TOKEN}" ]; then
         git remote set-url origin "https://${GITHUB_ACTOR}:${INPUT_TARGET_REPO_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
     fi
 


### PR DESCRIPTION
Fix a mistyping in the `push_updates.sh` when the `git remote set-url` is set. Previously the  existence of `INPUT_UPSTREAM_REPO_ACCESS_TOKEN` is done before applying the `INPUT_TARGET_REPO_TOKEN` in the command. 
This fix is addresses this [issue ](https://github.com/aormsby/Fork-Sync-With-Upstream-action/issues/53)