### PR TITLE
Bump nodejs from 12 to 16

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -82,5 +82,5 @@ outputs:
     description: 'true when new commits were included in this sync'
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'main.js'


### PR DESCRIPTION
GitHub has announced this news: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.