### PR TITLE
Bump node v16 to v22 in action.yaml

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -82,5 +82,5 @@ outputs:
     description: 'true when new commits were included in this sync'
 
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'main.js'

--- a/action.yaml
+++ b/action.yaml
@@ -82,5 +82,5 @@ outputs:
     description: 'true when new commits were included in this sync'
 
 runs:
-  using: 'node20'
+  using: 'node22'
   main: 'main.js'


### PR DESCRIPTION
In accordance with [GitHub Actions: Transitioning from Node 16 to Node 20](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/) bumping the node version for `action.yaml` from v16 to v20. If you wish, this can be further bumped to v22, but current LTS is v20.